### PR TITLE
Fix for save and option buttons disappearing in pause menu on lazytweaks

### DIFF
--- a/src/collection_menu/collection_nav.cpp
+++ b/src/collection_menu/collection_nav.cpp
@@ -1,5 +1,16 @@
 #include "collection_nav.hpp"
 
+#include "../z_button/z_button.hpp"
+#include "f_pc/f_pc_profile_lst.h"
+
+// another helper function, works a little bit differently this time though
+template <typename T>
+const T &shiftHIO(const T &member) {
+    // Return the amount of bytes to shift by only if on lazy tweaks, otherwise return 0 (shift by nothing)
+    int shiftByThis = isNativeZButtonEngine() ? 4 * static_cast<int>(sizeof(f32)) : 0;
+    return *reinterpret_cast<const T *>(reinterpret_cast<const u8 *>(&member) + shiftByThis);   // return the value to shift by after casting
+}
+
 HookAction on_get_item_tag_pre(ModContext*, void* args, void* ret, void*) {
     if (!is_collection_menu_enabled() || !args || !ret) return HOOK_CONTINUE;
     int i_tag1 = mods::arg<int>(args, 1);
@@ -61,7 +72,10 @@ HookAction on_cursor_pos_set_pre(ModContext*, void* args, void*, void*) {
     u8 curX = collect2D->mCursorX;
     u8 curY = collect2D->mCursorY;
 
+    const dMeter_drawCollectHIO_c &collectHIO = shiftHIO(g_drawHIO.mCollectScreen);
+
     // Scale all panes
+    // renamed usage of g_drawHIO to collectHIO pointer, will work regardless of branch
     for (u8 y = 0; y < 6; y++) {
         for (u8 x = 0; x < 7; x++) {
             J2DPane* pane = get_target_pane(collect2D, x, y);
@@ -69,18 +83,18 @@ HookAction on_cursor_pos_set_pre(ModContext*, void* args, void*, void*) {
                 if ((x != 0 || y != 0) && (x != 6 || y != 0)) {
                     if (y == 5) {
                         if (x == curX && y == curY) {
-                            pane->scale(g_drawHIO.mCollectScreen.mSelectSaveOptionScale,
-                                       g_drawHIO.mCollectScreen.mSelectSaveOptionScale);
+                            pane->scale(collectHIO.mSelectSaveOptionScale,
+                                       collectHIO.mSelectSaveOptionScale);
                         } else {
-                            pane->scale(g_drawHIO.mCollectScreen.mUnselectSaveOptionScale,
-                                       g_drawHIO.mCollectScreen.mUnselectSaveOptionScale);
+                            pane->scale(collectHIO.mUnselectSaveOptionScale,
+                                       collectHIO.mUnselectSaveOptionScale);
                         }
                     } else if (x == curX && y == curY) {
-                        pane->scale(g_drawHIO.mCollectScreen.mSelectItemScale,
-                                   g_drawHIO.mCollectScreen.mSelectItemScale);
+                        pane->scale(collectHIO.mSelectItemScale,
+                                   collectHIO.mSelectItemScale);
                     } else {
-                        pane->scale(g_drawHIO.mCollectScreen.mUnselectItemScale,
-                                   g_drawHIO.mCollectScreen.mUnselectItemScale);
+                        pane->scale(collectHIO.mUnselectItemScale,
+                                   collectHIO.mUnselectItemScale);
                     }
                 }
             }

--- a/src/visible_equipment/visible_equipment.cpp
+++ b/src/visible_equipment/visible_equipment.cpp
@@ -43,9 +43,10 @@ extern bool isNativeZButtonEngine();
 
 // this is a helper function for finding the correct address of a member if it doesn't line up with the SDK
 template <typename T>
-const T &addressShift(const T &member) { // template because it accepts a param regardless of type
-  const u32 actualSize = g_profile_ALINK.base.base.process_size; // size of daAlink_c on runtime
-  const size_t linkSize = sizeof(daAlink_c); // expected size based on dusklight's SDK
+const T &addressShift(const T &member) {                           // template because it accepts a param regardless of type
+  const u32 actualSize = g_profile_ALINK.base.base.process_size;   // size of daAlink_c on runtime
+  const size_t linkSize = sizeof(daAlink_c);                       // expected size based on dusklight's SDK
+
   // shift by the difference between the actual size and the expected size
   const int shiftByThis = static_cast<int>(actualSize) - static_cast<int>(linkSize);
 


### PR DESCRIPTION
Because LazyTweaks shifts the dMeter_drawHIO_c class by 16 bytes to accommodate Z-items, the retrieval of some pane items is off by the 16, causing the Save and Options buttons to disappear after the cursor is moved once. To fix this, on_cursor_pos_set_pre() will now use a reference that will return a value that works on either branch without an extra if/else (which is calculated by the helper function I wrote, shiftHIO())