### PR TITLE
Permafix

### DIFF
--- a/src/collection_menu/collection_nav.cpp
+++ b/src/collection_menu/collection_nav.cpp
@@ -1,5 +1,16 @@
 #include "collection_nav.hpp"
 
+#include "../z_button/z_button.hpp"
+#include "f_pc/f_pc_profile_lst.h"
+
+// another helper function, works a little bit differently this time though
+template <typename T>
+const T &shiftHIO(const T &member) {
+    // Return the amount of bytes to shift by only if on lazy tweaks, otherwise return 0 (shift by nothing)
+    int shiftByThis = isNativeZButtonEngine() ? 4 * static_cast<int>(sizeof(f32)) : 0;
+    return *reinterpret_cast<const T *>(reinterpret_cast<const u8 *>(&member) + shiftByThis);   // return the value to shift by after casting
+}
+
 HookAction on_get_item_tag_pre(ModContext*, void* args, void* ret, void*) {
     if (!is_collection_menu_enabled() || !args || !ret) return HOOK_CONTINUE;
     int i_tag1 = mods::arg<int>(args, 1);
@@ -61,7 +72,10 @@ HookAction on_cursor_pos_set_pre(ModContext*, void* args, void*, void*) {
     u8 curX = collect2D->mCursorX;
     u8 curY = collect2D->mCursorY;
 
+    const dMeter_drawCollectHIO_c &collectHIO = shiftHIO(g_drawHIO.mCollectScreen);
+
     // Scale all panes
+    // renamed usage of g_drawHIO to collectHIO pointer, will work regardless of branch
     for (u8 y = 0; y < 6; y++) {
         for (u8 x = 0; x < 7; x++) {
             J2DPane* pane = get_target_pane(collect2D, x, y);
@@ -69,18 +83,18 @@ HookAction on_cursor_pos_set_pre(ModContext*, void* args, void*, void*) {
                 if ((x != 0 || y != 0) && (x != 6 || y != 0)) {
                     if (y == 5) {
                         if (x == curX && y == curY) {
-                            pane->scale(g_drawHIO.mCollectScreen.mSelectSaveOptionScale,
-                                       g_drawHIO.mCollectScreen.mSelectSaveOptionScale);
+                            pane->scale(collectHIO.mSelectSaveOptionScale,
+                                       collectHIO.mSelectSaveOptionScale);
                         } else {
-                            pane->scale(g_drawHIO.mCollectScreen.mUnselectSaveOptionScale,
-                                       g_drawHIO.mCollectScreen.mUnselectSaveOptionScale);
+                            pane->scale(collectHIO.mUnselectSaveOptionScale,
+                                       collectHIO.mUnselectSaveOptionScale);
                         }
                     } else if (x == curX && y == curY) {
-                        pane->scale(g_drawHIO.mCollectScreen.mSelectItemScale,
-                                   g_drawHIO.mCollectScreen.mSelectItemScale);
+                        pane->scale(collectHIO.mSelectItemScale,
+                                   collectHIO.mSelectItemScale);
                     } else {
-                        pane->scale(g_drawHIO.mCollectScreen.mUnselectItemScale,
-                                   g_drawHIO.mCollectScreen.mUnselectItemScale);
+                        pane->scale(collectHIO.mUnselectItemScale,
+                                   collectHIO.mUnselectItemScale);
                     }
                 }
             }

--- a/src/collection_menu/collection_nav.cpp
+++ b/src/collection_menu/collection_nav.cpp
@@ -1,16 +1,5 @@
 #include "collection_nav.hpp"
 
-#include "../z_button/z_button.hpp"
-#include "f_pc/f_pc_profile_lst.h"
-
-// another helper function, works a little bit differently this time though
-template <typename T>
-const T &shiftHIO(const T &member) {
-    // Return the amount of bytes to shift by only if on lazy tweaks, otherwise return 0 (shift by nothing)
-    int shiftByThis = isNativeZButtonEngine() ? 4 * static_cast<int>(sizeof(f32)) : 0;
-    return *reinterpret_cast<const T *>(reinterpret_cast<const u8 *>(&member) + shiftByThis);   // return the value to shift by after casting
-}
-
 HookAction on_get_item_tag_pre(ModContext*, void* args, void* ret, void*) {
     if (!is_collection_menu_enabled() || !args || !ret) return HOOK_CONTINUE;
     int i_tag1 = mods::arg<int>(args, 1);
@@ -72,10 +61,7 @@ HookAction on_cursor_pos_set_pre(ModContext*, void* args, void*, void*) {
     u8 curX = collect2D->mCursorX;
     u8 curY = collect2D->mCursorY;
 
-    const dMeter_drawCollectHIO_c &collectHIO = shiftHIO(g_drawHIO.mCollectScreen);
-
     // Scale all panes
-    // renamed usage of g_drawHIO to collectHIO pointer, will work regardless of branch
     for (u8 y = 0; y < 6; y++) {
         for (u8 x = 0; x < 7; x++) {
             J2DPane* pane = get_target_pane(collect2D, x, y);
@@ -83,18 +69,18 @@ HookAction on_cursor_pos_set_pre(ModContext*, void* args, void*, void*) {
                 if ((x != 0 || y != 0) && (x != 6 || y != 0)) {
                     if (y == 5) {
                         if (x == curX && y == curY) {
-                            pane->scale(collectHIO.mSelectSaveOptionScale,
-                                       collectHIO.mSelectSaveOptionScale);
+                            pane->scale(g_drawHIO.mCollectScreen.mSelectSaveOptionScale,
+                                       g_drawHIO.mCollectScreen.mSelectSaveOptionScale);
                         } else {
-                            pane->scale(collectHIO.mUnselectSaveOptionScale,
-                                       collectHIO.mUnselectSaveOptionScale);
+                            pane->scale(g_drawHIO.mCollectScreen.mUnselectSaveOptionScale,
+                                       g_drawHIO.mCollectScreen.mUnselectSaveOptionScale);
                         }
                     } else if (x == curX && y == curY) {
-                        pane->scale(collectHIO.mSelectItemScale,
-                                   collectHIO.mSelectItemScale);
+                        pane->scale(g_drawHIO.mCollectScreen.mSelectItemScale,
+                                   g_drawHIO.mCollectScreen.mSelectItemScale);
                     } else {
-                        pane->scale(collectHIO.mUnselectItemScale,
-                                   collectHIO.mUnselectItemScale);
+                        pane->scale(g_drawHIO.mCollectScreen.mUnselectItemScale,
+                                   g_drawHIO.mCollectScreen.mUnselectItemScale);
                     }
                 }
             }

--- a/src/visible_equipment/visible_equipment.cpp
+++ b/src/visible_equipment/visible_equipment.cpp
@@ -43,10 +43,9 @@ extern bool isNativeZButtonEngine();
 
 // this is a helper function for finding the correct address of a member if it doesn't line up with the SDK
 template <typename T>
-const T &addressShift(const T &member) {                           // template because it accepts a param regardless of type
-  const u32 actualSize = g_profile_ALINK.base.base.process_size;   // size of daAlink_c on runtime
-  const size_t linkSize = sizeof(daAlink_c);                       // expected size based on dusklight's SDK
-
+const T &addressShift(const T &member) { // template because it accepts a param regardless of type
+  const u32 actualSize = g_profile_ALINK.base.base.process_size; // size of daAlink_c on runtime
+  const size_t linkSize = sizeof(daAlink_c); // expected size based on dusklight's SDK
   // shift by the difference between the actual size and the expected size
   const int shiftByThis = static_cast<int>(actualSize) - static_cast<int>(linkSize);
 

--- a/src/visible_equipment/visible_equipment.cpp
+++ b/src/visible_equipment/visible_equipment.cpp
@@ -66,9 +66,6 @@ static u32 getLinkShadowId(daAlink_c *alink) {
   }
 
   const u8 *basePtr = reinterpret_cast<const u8 *>(&alink->field_0x31a4);
-  if (isNativeZButtonEngine()) {
-    return *reinterpret_cast<const u32 *>(basePtr + sizeof(daPy_anmHeap_c));
-  }
 
   return static_cast<u32>(alink->field_0x31a4);
 }
@@ -387,18 +384,6 @@ static void renderLantern(daAlink_c *alink) {
     return;
   }
 
-  /** the current implementation technically works anyways because it checks two flags before checking mEquipItem
-  but I figure it couldn't hurt to set a guard just in case **/
-  if (isNativeZButtonEngine()) {
-    const u16 shiftedItem = addressShift(alink->mEquipItem); // get the shifted address of lantern
-    if (alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x1)) ||
-        alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x20000)) ||
-        shiftedItem == dItemNo_KANTERA_e) {
-      s_veLanternCallbackRegistered = false;
-      return;
-    }
-  }
-
   // Skip if active lantern is out
   if (alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x1)) ||
       alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x20000)) ||
@@ -633,19 +618,8 @@ static void on_alink_draw_post(ModContext *, void *, void *, void *) {
   }
 
   bool shouldShowBow = g_configVisibleEquipShowBow && checkShouldShowBow();
-  bool isBowInHand = false;
-
-  if (isNativeZButtonEngine()) {
-    /** shift the address of the bow item by the address shift calculated by helper function addressShift();
-    this should fix the bow not correctly coming off of Link's back when the bow is drawn **/
-    const u16 shiftedItem = addressShift(alink->mEquipItem);
-    isBowInHand = alink->checkBowAndSlingItem(shiftedItem) ||
-                     shiftedItem == dItemNo_BOW_e;
-  }
-  else {
-    isBowInHand = alink->checkBowAndSlingItem(alink->mEquipItem) ||
-                     (alink->mEquipItem == dItemNo_BOW_e);
-  }
+  bool isBowInHand = alink->checkBowAndSlingItem(alink->mEquipItem) ||
+                   (alink->mEquipItem == dItemNo_BOW_e);
 
   if (shouldShowBow) {
     renderBow(alink, shouldShowBow, isBowInHand);

--- a/src/visible_equipment/visible_equipment.cpp
+++ b/src/visible_equipment/visible_equipment.cpp
@@ -7,11 +7,13 @@
 #include "d/d_item_data.h"
 #include "d/d_kankyo.h"
 #include "f_pc/f_pc_name.h"
+#include "f_pc/f_pc_profile_lst.h"
 #include "m_Do/m_Do_ext.h"
 #include "m_Do/m_Do_mtx.h"
 #include "mods/api.h"
 #include "mods/svc/hook.hpp"
 #include "mods/svc/log.h"
+#include "../z_button/z_button.hpp"
 #include <cstdio>
 
 static const LogService *s_logSvc = nullptr;
@@ -38,6 +40,18 @@ inline s16 degToS16(f32 deg) {
 }
 
 extern bool isNativeZButtonEngine();
+
+// this is a helper function for finding the correct address of a member if it doesn't line up with the SDK
+template <typename T>
+const T &addressShift(const T &member) { // template because it accepts a param regardless of type
+  const u32 actualSize = g_profile_ALINK.base.base.process_size; // size of daAlink_c on runtime
+  const size_t linkSize = sizeof(daAlink_c); // expected size based on dusklight's SDK
+  // shift by the difference between the actual size and the expected size
+  const int shiftByThis = static_cast<int>(actualSize) - static_cast<int>(linkSize);
+
+  // get a new pointer to the member by shifting the address of the member by the difference
+  return *reinterpret_cast<const T *>(reinterpret_cast<const u8 *>(&member) + shiftByThis);
+}
 
 static u32 getLinkShadowId(daAlink_c *alink) {
   if (alink == nullptr) {
@@ -361,6 +375,18 @@ static void renderLantern(daAlink_c *alink) {
     return;
   }
 
+  /** the current implementation technically works anyways because it checks two flags before checking mEquipItem
+  but I figure it couldn't hurt to set a guard just in case **/
+  if (isNativeZButtonEngine()) {
+    const u16 shiftedItem = addressShift(alink->mEquipItem); // get the shifted address of lantern
+    if (alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x1)) ||
+        alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x20000)) ||
+        shiftedItem == dItemNo_KANTERA_e) {
+      s_veLanternCallbackRegistered = false;
+      return;
+    }
+  }
+
   // Skip if active lantern is out
   if (alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x1)) ||
       alink->checkNoResetFlg2(static_cast<daPy_py_c::daPy_FLG2>(0x20000)) ||
@@ -599,8 +625,19 @@ static void on_alink_draw_post(ModContext *, void *, void *, void *) {
   }
 
   bool shouldShowBow = g_configVisibleEquipShowBow && checkShouldShowBow();
-  bool isBowInHand = alink->checkBowAndSlingItem(alink->mEquipItem) ||
+  bool isBowInHand = false;
+
+  if (isNativeZButtonEngine()) {
+    /** shift the address of the bow item by the address shift calculated by helper function addressShift();
+    this should fix the bow not correctly coming off of Link's back when the bow is drawn **/
+    const u16 shiftedItem = addressShift(alink->mEquipItem);
+    isBowInHand = alink->checkBowAndSlingItem(shiftedItem) ||
+                     shiftedItem == dItemNo_BOW_e;
+  }
+  else {
+    isBowInHand = alink->checkBowAndSlingItem(alink->mEquipItem) ||
                      (alink->mEquipItem == dItemNo_BOW_e);
+  }
 
   if (shouldShowBow) {
     renderBow(alink, shouldShowBow, isBowInHand);

--- a/src/visible_equipment/visible_equipment.cpp
+++ b/src/visible_equipment/visible_equipment.cpp
@@ -43,9 +43,10 @@ extern bool isNativeZButtonEngine();
 
 // this is a helper function for finding the correct address of a member if it doesn't line up with the SDK
 template <typename T>
-const T &addressShift(const T &member) { // template because it accepts a param regardless of type
-  const u32 actualSize = g_profile_ALINK.base.base.process_size; // size of daAlink_c on runtime
-  const size_t linkSize = sizeof(daAlink_c); // expected size based on dusklight's SDK
+const T &addressShift(const T &member) {                           // template because it accepts a param regardless of type
+  const u32 actualSize = g_profile_ALINK.base.base.process_size;   // size of daAlink_c on runtime
+  const size_t linkSize = sizeof(daAlink_c);                       // expected size based on dusklight's SDK
+
   // shift by the difference between the actual size and the expected size
   const int shiftByThis = static_cast<int>(actualSize) - static_cast<int>(linkSize);
 

--- a/src/z_button/z_button.cpp
+++ b/src/z_button/z_button.cpp
@@ -7,6 +7,7 @@
 #include "z_itemwheel.cpp"
 #include "z_item_actions.cpp"
 #include "z_draw.cpp"
+#include "f_pc/f_pc_profile_lst.h"
 
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
@@ -18,33 +19,20 @@
 #endif
 
 bool isNativeZButtonEngine() {
-    static int s_cachedResult = -1;
-    if (s_cachedResult != -1) {
-        return s_cachedResult == 1;
-    }
+    /** this should now more definitively check if mItemHeap is [2] or [3] by checking if the size of daAlink_c on
+    runtime is correct vs what the SDK assumes it is **/
+    const u32 actualSize = g_profile_ALINK.base.base.process_size; // size of daAlink_c on runtime
+    const size_t linkSize = sizeof(daAlink_c); // expected size based on dusklight's SDK
+    const size_t animHeapSize = sizeof(daPy_anmHeap_c); // expected size of mItemHeap/mAnmHeap based on dusklight's SDK
 
-#if defined(_WIN32)
-    HMODULE hExe = GetModuleHandleA(nullptr);
-    if (hExe != nullptr) {
-        if (GetProcAddress(hExe, "?checkShieldCrouch@daAlink_c@@QEAAHXZ") != nullptr ||
-            GetProcAddress(hExe, "?setShieldCrouch@daAlink_c@@QEAAXXZ") != nullptr ||
-            GetProcAddress(hExe, "?loseRupees@daAlink_c@@QEAAXXZ") != nullptr)
-        {
-            s_cachedResult = 1;
-            return true;
-        }
-    }
-#else
-    if (dlsym(RTLD_DEFAULT, "_ZN8daAlink_c17checkShieldCrouchEv") != nullptr ||
-        dlsym(RTLD_DEFAULT, "_ZN8daAlink_c15setShieldCrouchEv") != nullptr ||
-        dlsym(RTLD_DEFAULT, "_ZN8daAlink_c10loseRupeesEv") != nullptr)
-    {
-        s_cachedResult = 1;
+    /** lazy tweaks or a z-items fork that increased mItemHeap to [3] will shift the size of daAlink_c by more than
+    what is calculated here, but this will know it's specifically a z-items fork if daAlink_c is increased by
+    specifically 32 (another mItemHeap) (assuming no other heaps are increased or any other size is added);
+    if a fork happens to do other weird stuff (which I'm going to avoid doing with lazy tweaks),
+    this won't catch it, but this works for now unless a universal implementation is wanted **/
+    if (static_cast<const int>(actualSize) == static_cast<const int>(linkSize) + static_cast<const int>(animHeapSize)) {
         return true;
     }
-#endif
-
-    s_cachedResult = 0;
     return false;
 }
 


### PR DESCRIPTION
Fixed on my end with Lazy Tweaks so aside from keeping z-item hooks from installing, no more workarounds should be needed in the future (at least because of struct offset differences). I'm gonna release a new LT version as soon as I can so people will actually have access to it, since removing these patches here will mean Lazy Tweaks v3 won't work anymore unless it's with a prior version of Twilit Essentials